### PR TITLE
Pass some strings by const reference.

### DIFF
--- a/src/analysis/checks.cpp
+++ b/src/analysis/checks.cpp
@@ -67,8 +67,8 @@ std::string mergeCollection(const std::set<std::string> &col)
 
 void reportCollections(Node *node,
                        const std::string &name,
-                       std::set<std::string> col1,
-                       std::set<std::string> col2)
+                       const std::set<std::string>& col1,
+                       const std::set<std::string>& col2)
 {
     std::string str1 = mergeCollection(col1);
     std::string str2 = mergeCollection(col2);

--- a/src/analysis/reports.cpp
+++ b/src/analysis/reports.cpp
@@ -214,8 +214,8 @@ void reportWrongCheck(Node *node)
 
 void reportCollectionsDifferent(Node *node,
                                 const std::string &name,
-                                std::string str1,
-                                std::string str2)
+                                const std::string& str1,
+                                const std::string& str2)
 {
     std::string str = "internal collections '%s' is different.\nwant: " +
         str2 +

--- a/src/analysis/reports.h
+++ b/src/analysis/reports.h
@@ -59,8 +59,8 @@ namespace Analysis
 
     void reportCollectionsDifferent(Node *node,
                                     const std::string &name,
-                                    std::string str1,
-                                    std::string str2);
+                                    const std::string& str1,
+                                    const std::string& str2);
 }
 
 #endif // ANALYSIS_REPORTS_H

--- a/src/parsers/generic.cpp
+++ b/src/parsers/generic.cpp
@@ -35,7 +35,7 @@ namespace Generic
 
 Node *createParseNode(Node *parent,
                       tree gccNode,
-                      std::string tag,
+                      const std::string& tag,
                       int parseChilds)
 {
     return createParseNode(parent,

--- a/src/parsers/generic.h
+++ b/src/parsers/generic.h
@@ -44,7 +44,7 @@ namespace Generic
 
     Node *createParseNode(Node *parent,
                           tree gccNode,
-                          std::string tag = "",
+                          const std::string& tag = "",
                           int parseChilds = INT_MAX);
 
     Node *createParseNode(Node *parent,


### PR DESCRIPTION
This fixes a few warnings generated by [Cppcheck](https://github.com/danmar/cppcheck) 1.87 saying that some `string` parameters should be passed by `const` reference. I changed some of the function declarations as well to match the new definitions but I'm not sure where to find the declaration for `reportCollections`.

```
[src\analysis\checks.cpp:70]: (performance) Function parameter 'col1' should be passed by const reference.
[src\analysis\checks.cpp:71]: (performance) Function parameter 'col2' should be passed by const reference.
[src\analysis\reports.cpp:217]: (performance) Function parameter 'str1' should be passed by const reference.
[src\analysis\reports.cpp:218]: (performance) Function parameter 'str2' should be passed by const reference.
[src\parsers\generic.cpp:38]: (performance) Function parameter 'tag' should be passed by const reference.
```